### PR TITLE
Enhancement minor change to creating order

### DIFF
--- a/locales/order.en.yml
+++ b/locales/order.en.yml
@@ -109,7 +109,9 @@ en:
         "invoice_numbers":        {
           1: "INV001"
         },
-        "order_line_item_ids":    []
+        "order_line_item_ids":    [
+          
+        ]
       }
     ]
     gecko:
@@ -117,7 +119,11 @@ en:
         company_id: 1,
         issued_at: Time.now,
         billing_address_id: 1,
-        shipping_address_id: 1
+        shipping_address_id: 1,
+        order_line_items: [
+          {variant_id: 123, quantity: 2},
+          {variant_id: 456, quantity: 5}
+        ]
       }
       update: {
         status: "active",

--- a/source/includes/guides/_order_flow.md
+++ b/source/includes/guides/_order_flow.md
@@ -12,7 +12,7 @@
     "status": "active",
     "issued_at": "21-02-2014",
     "order_line_items": [
-      { "variant_id": 14, "quantity": 1 }
+      { "variant_id": 14, "quantity": 1 },
       { "variant_id": 15, "quantity": 2 }
     ]
   }


### PR DESCRIPTION
## Summary 

Minor correction of typo and show example of order_line_items array when creating order

## Motivation

One customer who is using our API thought that he needs separate calls to create each order line item. This could be because there wasn't an explicit example to demonstrate that he can pass all the order line items into a single array when making the POST call to create an order. 
