### PR TITLE
Update docs for Image management

### DIFF
--- a/locales/image.en.yml
+++ b/locales/image.en.yml
@@ -13,7 +13,9 @@ en:
     json: [
       {
         id: 2,
+        product_id: 1,
         variant_id: 1,
+        variant_ids: [1, 2],
         uploader_id: 1,
         name: "",
         position: 1,
@@ -26,7 +28,9 @@ en:
       },
       {
         id: 1,
+        product_id: 1,
         variant_id: 1,
+        variant_ids: [1, 2],
         uploader_id: 1,
         name: null,
         position: 1,
@@ -41,7 +45,8 @@ en:
     ]
     gecko:
       create: {
-        variant_id: 1,
+        product_id: 1,
+        variant_ids: [1, 2],
         url: "http://www.thisismyimage.com/image.png"
       }
 
@@ -52,10 +57,26 @@ en:
         description: "A unique identifier for the resource.",
         readonly: true,
       },
+      product_id: {
+        name: "product_id",
+        type: "Integer",
+        description: "The product to which the image belongs.",
+        filterable: "Filter images by product",
+        creatable: true,
+        required: true,
+      },
       variant_id: {
         name: "variant_id",
         type: "Integer",
         description: "The variant to which the image belongs.",
+        filterable: "Filter images by variant",
+        creatable: true,
+        deprecated: true,
+      },
+      variant_ids: {
+        name: "variant_ids",
+        type: "Array",
+        description: "The variants to which the image belongs.",
         filterable: "Filter images by variant",
         creatable: true,
         required: true,

--- a/locales/product.en.yml
+++ b/locales/product.en.yml
@@ -26,6 +26,10 @@ en:
         supplier_ids: [
           3
         ],
+        image_ids: [
+          1,
+          2
+        ],
         tags: "candy,chocolate",
         variant_ids: [
           4,
@@ -54,6 +58,7 @@ en:
         supplier_ids: [
           3
         ],
+        image_ids: [],
         tags: "candy,summer",
         variant_ids: [
           2,
@@ -115,7 +120,7 @@ en:
       image_url: {
         name: "image_url",
         type: "String",
-        description: "First image of children variants (sorted on position)",
+        description: "First image of the product (sorted on position)",
         readonly: true,
       },
       name: {
@@ -184,6 +189,14 @@ en:
         description: "Should currently only be one ID for backwards compatibility purposes",
         updatable: true,
         creatable: true,
+        beta: true,
+      },
+      image_ids: {
+        name: "image_ids",
+        type: "Array",
+        description: "The IDs of all the images linked to the product",
+        updatable: true,
+        creatable: false,
         beta: true,
       },
       tags: {

--- a/locales/variant.en.yml
+++ b/locales/variant.en.yml
@@ -434,8 +434,9 @@ en:
       image_ids: {
         name: "image_ids",
         type: "Array",
-        description: "",
-        readonly: true,
+        description: "Images assigned to the variant. The order of the Image IDs here is the position of the images on the variant.",
+        updatable: true,
+        creatable: true,
       },
       variant_prices: {
         name: "variant_prices",


### PR DESCRIPTION
Image management documentation.

 - Deprecate `variant_id` on `Image`.
 - Added `image_ids` to `Product`
 - Added `product_id` to `Image`
 - Added `variant_ids` to `Image`
