### PR TITLE
[ENHANCEMENT] Add sample code for actions

### DIFF
--- a/locales/order.en.yml
+++ b/locales/order.en.yml
@@ -430,22 +430,22 @@ en:
       },
     }
     actions: {
-      description: "Use the following endpoints to manage the order's invoice, payment and fulfillment. `POST /orders/[:order_id]/actions/<action>`",
+      description: "Use the following endpoints to manage the order's invoice, payment and fulfillment. `POST /orders/[:order_id]/actions/[:action]`",
       endpoints: [
         {
-          endpoint: "`invoice`",
+          endpoint: "invoice",
           description: "Invoice the order"
         },
         {
-          endpoint: "`pay`",
+          endpoint: "pay",
           description: "Pay for the order"
         },
         {
-          endpoint: "`pack`",
+          endpoint: "pack",
           description: "Create a fulfillment with status: `packed`"
         },
         {
-          endpoint: "`fulfil`",
+          endpoint: "fulfil",
           description: "Create a fulfillment with status: `fulfilled`"
         }
       ]

--- a/locales/order.en.yml
+++ b/locales/order.en.yml
@@ -447,6 +447,10 @@ en:
         {
           endpoint: "fulfil",
           description: "Create a fulfillment with status: `fulfilled`"
+        },
+        {
+          endpoint: "void",
+          description: "Void the order"
         }
       ]
     }

--- a/locales/purchase_order.en.yml
+++ b/locales/purchase_order.en.yml
@@ -290,10 +290,10 @@ en:
       },
     }
     actions: {
-      description: "Use the following endpoints to manage the receiving of the purchase order. `POST /purchase_orders/[:purchase_order_id]/actions/<action>`",
+      description: "Use the following endpoints to manage the receiving of the purchase order. `POST /purchase_orders/[:purchase_order_id]/actions/[:action]`",
       endpoints: [
         {
-          endpoint: "`receive`",
+          endpoint: "receive",
           description: "Create a procurement for the purchase order"
         }
       ]

--- a/locales/stock_adjustment.en.yml
+++ b/locales/stock_adjustment.en.yml
@@ -129,10 +129,10 @@ en:
       }
     }
     actions: {
-      description: "Use the following endpoints to manage the reverting of the stock adjustment. `POST /stock_adjustments/[:stock_adjustment_id]/actions/<action>`",
+      description: "Use the following endpoints to manage the reverting of the stock adjustment. `POST /stock_adjustments/[:stock_adjustment_id]/actions/[:action]`",
       endpoints: [
         {
-          endpoint: "`revert`",
+          endpoint: "revert",
           description: "Revert the stock adjustment"
         }
       ]

--- a/locales/stock_transfer.en.yml
+++ b/locales/stock_transfer.en.yml
@@ -146,14 +146,14 @@ en:
       }
     }
     actions: {
-      description: "Use the following endpoints to manage the receiving or reverting of the stock transfer. `POST /stock_transfers/[:stock_transfer_id]/actions/<action>`",
+      description: "Use the following endpoints to manage the receiving or reverting of the stock transfer. `POST /stock_transfers/[:stock_transfer_id]/actions/[:action]`",
       endpoints: [
         {
-          endpoint: "`receive`",
+          endpoint: "receive",
           description: "Receive the stock transfer"
         },
         {
-          endpoint: "`revert`",
+          endpoint: "revert",
           description: "Revert the stock transfer"
         }
       ]

--- a/source/includes/_show_actions.md.erb
+++ b/source/includes/_show_actions.md.erb
@@ -2,8 +2,13 @@
 
 <%= t(".actions.description", scope: resource) %>
 
+```shell
+curl -X GET -H "Content-type: application/json" -H "Authorization: Bearer <ACCESS_TOKEN>"
+https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/[:<%= t('.resource_name', scope: resource) %>_id]/actions/[:<%= t('.resource_name', scope: resource) %>_action]
+```
+
 | Action                         | Description          
 | ------------------------------ | ------------- 
 <% t(".actions.endpoints", scope: resource).each do |endpoint| %>
-  <%= endpoint[:endpoint] %> | <%= endpoint[:description] %>
+  `<%= endpoint[:endpoint] %>` | <%= endpoint[:description] %>
 <% end %>


### PR DESCRIPTION
Currently, the actions doesn't have sample code for how they would look like. This PR add those actions and also adds the missing `void` action for `orders`. No support yet for actions in the Gecko gem.

Before:
<img width="1195" alt="screen shot 2018-10-03 at 2 49 05 pm" src="https://user-images.githubusercontent.com/2204029/46394369-80939480-c71b-11e8-8a41-39825524a963.png">

After:
<img width="1198" alt="screen shot 2018-10-03 at 2 48 25 pm" src="https://user-images.githubusercontent.com/2204029/46394331-6a85d400-c71b-11e8-84e3-3338e2baa98e.png">