### PR TITLE
[BUGFIX] Fix generator code

### DIFF
--- a/generate.thor
+++ b/generate.thor
@@ -3,6 +3,8 @@ require 'active_support/core_ext/hash'
 require 'gecko'
 require 'pry'
 require 'oauth2'
+require 'dotenv'
+Dotenv.load!
 
 class Generate < Thor
   include Thor::Actions

--- a/generate.thor
+++ b/generate.thor
@@ -2,6 +2,8 @@ require 'active_support/inflector'
 require 'active_support/core_ext/hash'
 require 'gecko'
 require 'pry'
+require 'oauth2'
+
 class Generate < Thor
   include Thor::Actions
 
@@ -56,7 +58,6 @@ en:
 
   def json
     @json ||= JSON.parse(access_token.request(:get, @plural).body).first.last.map(&:symbolize_keys).first(3)
-  rescue
   end
 
   def attributes


### PR DESCRIPTION
Currently, when attempting to generate a resource, a misleading error appears (`undefined method first for Nilclass`). This is due to OAuth not being present in the `thor` code. Also, the `rescue` block in that method masks the OAuth error and returns `nil`, which results in the `undefined method first for Nilclass` error message).

This PR removes that `rescue` message, ensuring that the correct error is shown. (Note that if we provided a correct OAuth Application ID, Secret, and Key, an Order resource will be generated.)

Before:
<img width="1198" alt="screen shot 2018-10-11 at 4 36 08 pm" src="https://user-images.githubusercontent.com/2204029/46791556-01820a00-cd74-11e8-84a1-0b30144bd6fc.png">

After:
<img width="897" alt="screen shot 2018-10-11 at 4 35 51 pm" src="https://user-images.githubusercontent.com/2204029/46791580-11015300-cd74-11e8-9a69-06319611021a.png">

