### PR TITLE
Feature/void sa

### DIFF
--- a/locales/address.en.yml
+++ b/locales/address.en.yml
@@ -9,6 +9,7 @@ en:
     resource_klass: "Address"
     resource_name: "address"
     resource_plural: "addresses"
+    used_in_sales_order: true
     json: [
       {
         id: 6,

--- a/locales/company.en.yml
+++ b/locales/company.en.yml
@@ -5,6 +5,7 @@ en:
     resource_klass: "Company"
     resource_name: "company"
     resource_plural: "companies"
+    used_in_sales_order: true
     json: [
       {
         id: 4,

--- a/locales/contact.en.yml
+++ b/locales/contact.en.yml
@@ -9,6 +9,7 @@ en:
     resource_klass: "Contact"
     resource_name: "contact"
     resource_plural: "contacts"
+    used_in_sales_order: true
     json: [
       {
         id: 7,

--- a/locales/currency.en.yml
+++ b/locales/currency.en.yml
@@ -5,6 +5,7 @@ en:
     resource_klass: "Currency"
     resource_name: "currency"
     resource_plural: "currencies"
+    used_in_sales_order: true
     json: [
       {
         id: 2,

--- a/locales/location.en.yml
+++ b/locales/location.en.yml
@@ -5,6 +5,7 @@ en:
     resource_klass: "Location"
     resource_name: "location"
     resource_plural: "locations"
+    used_in_sales_order: true
     json: [
       {
         id: 2,

--- a/locales/payment_term.yml
+++ b/locales/payment_term.yml
@@ -5,6 +5,7 @@ en:
     resource_klass: "PaymentTerm"
     resource_name: "payment_term"
     resource_plural: "payment_terms"
+    used_in_sales_order: true
     json: [
       {
         id: 3,

--- a/locales/price_list.en.yml
+++ b/locales/price_list.en.yml
@@ -5,6 +5,7 @@ en:
     resource_klass: "PriceList"
     resource_name: "price_list"
     resource_plural: "price_lists"
+    used_in_sales_order: true
     json: [
       {
         id: "buy",

--- a/locales/stock_adjustment.en.yml
+++ b/locales/stock_adjustment.en.yml
@@ -4,7 +4,6 @@ en:
     enable_actions: true
     child: "stock_adjustment_line_item"
     disable_update: true
-    disable_destroy: true
     resource_article: "a"
     resource_klass: "StockAdjustment"
     resource_name: "stock_adjustment"

--- a/locales/stock_adjustment.en.yml
+++ b/locales/stock_adjustment.en.yml
@@ -1,7 +1,6 @@
 ---
 en:
   stock_adjustment:
-    enable_actions: true
     child: "stock_adjustment_line_item"
     disable_update: true
     resource_article: "a"
@@ -127,13 +126,4 @@ en:
         description: "",
         readonly: true,
       }
-    }
-    actions: {
-      description: "Use the following endpoints to manage the reverting of the stock adjustment. `POST /stock_adjustments/[:stock_adjustment_id]/actions/[:action]`",
-      endpoints: [
-        {
-          endpoint: "revert",
-          description: "Revert the stock adjustment"
-        }
-      ]
     }

--- a/locales/stock_adjustment_line_item.en.yml
+++ b/locales/stock_adjustment_line_item.en.yml
@@ -115,7 +115,7 @@ en:
       price: {
         name: "price",
         type: "String",
-        description: "",
+        description: "Required only when quantity is greater than 0. For negative quantities, the current Moving Average Cost will be assigned automatically.",
         updatable: true,
         creatable: true,
         required: true,

--- a/locales/stock_adjustment_line_item.en.yml
+++ b/locales/stock_adjustment_line_item.en.yml
@@ -2,6 +2,7 @@
 en:
   stock_adjustment_line_item:
     disable_update: true
+    disable_destroy: true
     parent: "stock_adjustment"
     parent_article: "a"
     parent_klass: "StockAdjustment"

--- a/locales/tax_type.en.yml
+++ b/locales/tax_type.en.yml
@@ -5,6 +5,7 @@ en:
     resource_klass: "TaxType"
     resource_name: "tax_type"
     resource_plural: "tax_types"
+    used_in_sales_order: true
     json: [
       {
         id: 3,

--- a/locales/user.en.yml
+++ b/locales/user.en.yml
@@ -7,6 +7,7 @@ en:
     resource_klass: "User"
     resource_name: "user"
     resource_plural: "users"
+    used_in_sales_order: true
     json: [
       {
         id: 1,

--- a/locales/variant.en.yml
+++ b/locales/variant.en.yml
@@ -9,6 +9,7 @@ en:
     resource_klass: "Variant"
     resource_name: "variant"
     resource_plural: "variants"
+    used_in_sales_order: true
     json: [
       {
         id: 3,

--- a/source/includes/_destroy_request.md.erb
+++ b/source/includes/_destroy_request.md.erb
@@ -21,7 +21,10 @@ https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/1
 >
 > Returns 204 status when the <%= t(".resource_name", scope: resource) %> gets deleted successfully.
 
-Permanently deletes <%= t(".resource_article", scope: resource) %> <%= t(".resource_name", scope: resource) %>. It cannot be undone. This <%= t(".resource_name", scope: resource) %> is no longer available for future Sales Orders.
+Permanently deletes <%= t(".resource_article", scope: resource) %> <%= t(".resource_name", scope: resource) %>. It cannot be undone.
+<% if t(".used_in_sales_order", scope: resource) == true %>
+  This <%= t(".resource_name", scope: resource) %> will no longer be available for future Sales Order.
+<% end %>
 
 ### HTTP Request
 `DELETE https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/{RESOURCE_ID}/`


### PR DESCRIPTION
We now have a destroy endpoint for Stock Adjustments and we no longer needed the revert endpoint.
So far only one application is using the endpoint. We will email them, we won't remove the revert code yet on the main app until we are sure that nobody is using the endpoint anymore.