### PR TITLE
Tax rate tax component

### DIFF
--- a/locales/tax_type.en.yml
+++ b/locales/tax_type.en.yml
@@ -9,13 +9,13 @@ en:
     json: [
       {
         id: 3,
-        code: "PURCHASES",
+        code: "RETAIL",
         imported_from: null,
-        name: "Purchases Tax",
+        name: "Retail",
         status: "active",
         quickbooks_online_id: null,
         xero_online_id: null,
-        effective_rate: "15.0",
+        effective_rate: "10.0",
         tax_component_ids: [
           3
         ]
@@ -50,7 +50,15 @@ en:
     gecko:
       create: {
         name: "Retail",
-        code: "RETAIL"
+        code: "RETAIL",
+        tax_components: [
+          {
+            "position": 0,
+            "label": "Retail GST",
+            "rate": 10,
+            "compound": false
+          }
+        ]
       }
       update: {
         name: "Wholesale",
@@ -109,10 +117,10 @@ en:
         description: "Computed rate of child tax_components",
         readonly: true
       },
-      tax_component_ids: {
-        name: "tax_component_ids",
+      tax_component: {
+        name: "tax_components",
         type: "Array",
-        description: "",
-        readonly: true
+        description: "An array of Tax Components that the tax rate is composed of",
+        creatable: true
       }
     }

--- a/source/docs.html.md.erb
+++ b/source/docs.html.md.erb
@@ -68,6 +68,7 @@ resources:
   - stock_transfer
   - stock_transfer_line_item
   - tax_type
+  - tax_component
   - user
   - variant
   - webhook


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/19462912/66304427-b58a8680-e92f-11e9-991b-4f658fc6eb5e.png)

Tax type controller allows for creation of a tax type with a `tax_component` [param](https://github.com/tradegecko/tradegecko/blob/develop/app/policies/tax_type_policy.rb#L5-L13). Added documentation for creating tax types with a tax component payload. Also added the documentations for tax component CRUD operations (was removed in https://github.com/tradegecko/smaug/commit/978ac8f7978077a9c369d26b9a74124a86c94e34, not sure of the context here).

Closes off [TG-16393](https://tradegecko.atlassian.net/browse/TG-16393) and https://github.com/tradegecko/smaug/issues/81.