### PR TITLE
Fix the invoice_line_item_ids payload key

### DIFF
--- a/locales/invoice.en.yml
+++ b/locales/invoice.en.yml
@@ -30,14 +30,8 @@ en:
         currency_id: 1,
         status: "active",
         invoice_line_item_ids: [
-         {
-          "quantity": "1.0",
-          "order_line_item_id": 123
-        },
-         {
-          "quantity": "1.0",
-          "order_line_item_id": 456
-        }
+          1,
+          2
         ],
         payment_ids: [ ],
         refund_ids: [ ]


### PR DESCRIPTION
Fixes the `invoice_line_items_ids` value to represent ids instead of line_item obj