### PR TITLE
[FEATURE] Expose Variant Composition and Packsize APIs

### DIFF
--- a/locales/variant.en.yml
+++ b/locales/variant.en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   variant:
+    enable_actions: true
     parent: "product"
     parent_article: "a"
     parent_klass: "Product"
@@ -509,4 +510,17 @@ en:
         readonly: true,
         deprecated: true,
       },
+    }
+    actions: {
+      description: "Use the following endpoints to get more details about the variant type breakdown. `GET /variants/[:variant_id]/[:action]`",
+      endpoints: [
+        {
+          endpoint: "composition",
+          description: "Use this action when the variant `composite` flag is `true`. Gets the composition of the variant bundle, if the variant was a composite/bundle. Result is empty if the variant is simple or manufactured."
+        },
+        {
+          endpoint: "packsizes",
+          description: "Use this action when the variant `packsize` flag is `true`. Gets the details of the packsize variant. Result is empty if the variant is simple, manufactured, or a bundle of different variants."
+        }
+      ]
     }


### PR DESCRIPTION
### Summary
Expose `variants/[:variant_id]/composition` and `variants/[:variant_id]/packsizes` API details to public consumers to fetch the composition details of their bundles and packsizes.

### Next Best Alternatives:
- We can add `breakdown=true` flag to TradeGecko's variant API to allow a reduced fetch of the variant and its composition/packsize information in one go.
