### PR TITLE
[FEATURE] Add Composition API Resource

### DIFF
--- a/locales/composition.en.yml
+++ b/locales/composition.en.yml
@@ -1,0 +1,78 @@
+---
+en:
+  composition:
+    disable_create: true
+    disable_destroy: true
+    disable_update: true
+    resource_article: "a"
+    resource_klass: "Composition"
+    resource_name: "composition"
+    resource_plural: "composition"
+    resource_path: "variants/composition"
+    json: [
+      {
+        bundle_id: 151235,
+        bundle_sku: "B-SKU-001",
+        component_id: 341234,
+        component_sku: "SKU-002",
+        quantity: "20"
+      },
+      {
+        bundle_id: 151235,
+        bundle_sku: "B-SKU-001",
+        component_id: 341235,
+        component_sku: "SKU-003",
+        quantity: "10"
+      }
+    ]
+
+    gecko:
+      index: {
+        sku: [B-SKU-001]
+      }
+      show: {
+        id: 151235
+      }
+
+    filters: {
+      timestamp_search: false,
+      ids: {
+        description: "An Array of Bundle IDs"
+      }
+    }
+
+    attributes: {
+      bundle_id: {
+        name: "bundle_id",
+        type: "Integer",
+        readonly: true,
+        description: "The unique bundle Id.",
+      },
+      bundle_sku: {
+        name: "bundle_sku",
+        type: "String",
+        readonly: true,
+        description: "The given bundle SKU.",
+        filterable: "Filter by Bundle SKU via `sku` parameter"
+      },
+      component_id: {
+        name: "component_id",
+        type: "Integer",
+        readonly: true,
+        description: "The unique bundle-component Id."
+      },
+      component_sku: {
+        name: "component_sku",
+        type: "String",
+        readonly: true,
+        description: "The given component SKU."
+      },
+      quantity: {
+        name: "quantity",
+        type: "String",
+        readonly: true,
+        description: "The decimal composition quantity of the component as part of the bundle."
+      }
+    }
+
+

--- a/locales/composition.en.yml
+++ b/locales/composition.en.yml
@@ -46,33 +46,31 @@ en:
         name: "bundle_id",
         type: "Integer",
         readonly: true,
-        description: "The unique bundle Id.",
+        description: "The ID corresponding to the bundle variant. (Must be composite: true)",
       },
       bundle_sku: {
         name: "bundle_sku",
         type: "String",
         readonly: true,
-        description: "The given bundle SKU.",
+        description: "The provided bundle variant's SKU.",
         filterable: "Filter by Bundle SKU via `sku` parameter"
       },
       component_id: {
         name: "component_id",
         type: "Integer",
         readonly: true,
-        description: "The unique bundle-component Id."
+        description: "The ID corresponding to this particular component variant of the bundle."
       },
       component_sku: {
         name: "component_sku",
         type: "String",
         readonly: true,
-        description: "The given component SKU."
+        description: "The provided component variant's SKU."
       },
       quantity: {
         name: "quantity",
         type: "String",
         readonly: true,
-        description: "The decimal composition quantity of the component as part of the bundle."
+        description: "The quantity of this component variant required to make up the bundle."
       }
     }
-
-

--- a/source/docs.html.md.erb
+++ b/source/docs.html.md.erb
@@ -45,6 +45,7 @@ resources:
   - account
   - address
   - company
+  - composition
   - contact
   - currency
   - fulfillment

--- a/source/includes/_create_request.md.erb
+++ b/source/includes/_create_request.md.erb
@@ -21,7 +21,7 @@ gecko.access_token = access_token
 
 ```shell
 curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <ACCESS_TOKEN>"
-https://api.tradegecko.com/<%= resource.resource_plural %>/ -d '{"<%= resource.resource_name %>":<%= resource.gecko[:create].to_json %>}'
+https://api.tradegecko.com/<%= resource.resource_path || resource.resource_plural %>/ -d '{"<%= resource.resource_name %>":<%= resource.gecko[:create].to_json %>}'
 ```
 
 ```json
@@ -66,4 +66,4 @@ This endpoint also accepts embedded <%= resource.child.pluralize %>.
 <% end %>
 <% end %>
 ### HTTP Request
-`POST https://api.tradegecko.com/<%= resource.resource_plural %>/`
+`POST https://api.tradegecko.com/<%= resource.resource_path || resource.resource_plural %>/`

--- a/source/includes/_index_request.md.erb
+++ b/source/includes/_index_request.md.erb
@@ -1,4 +1,6 @@
-## List all <%= t(".resource_plural", scope: resource) %>
+<% plural_name = t(".resource_plural", scope: resource) %>
+<% resource_path = t(".resource_path", scope: resource).include?("missing") ? plural_name : t(".resource_path", scope: resource) %>
+## List all <%= plural_name %>
 <% unless t('.gecko.unavailable', scope: resource) == true %>
 ```ruby
 require 'gecko-ruby'
@@ -6,13 +8,15 @@ gecko = Gecko::Client.new(<OAUTH_ID>, <OAUTH_SECRET>)
 access_token = OAuth2::AccessToken.new(gecko.oauth_client, <ACCESS_TOKEN>)
 gecko.access_token = access_token
 
-gecko.<%= t(".resource_klass", scope: resource) %>.where(limit: 25, status: 'active')
+<% r = build_resource(t(".resource_name", scope: resource)) %>
+<% index_params = r.gecko[:index]&.present? ? r.gecko[:index] : "limit: 25, status: 'active'"  %>
+gecko.<%= t(".resource_klass", scope: resource) %>.where(<%= index_params %>)
 ```
 <% end %>
 
 ```shell
 curl -X GET -H "Content-type: application/json" -H "Authorization: Bearer <ACCESS_TOKEN>"
-https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/
+https://api.tradegecko.com/<%= resource_path %>/
 ```
 
 ```json
@@ -24,16 +28,21 @@ https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/
 Returns a list of <%= t(".resource_plural", scope: resource) %> you’ve previously created. The <%= t(".resource_plural", scope: resource) %> are returned in sorted order, with the most recent <%= t(".resource_plural", scope: resource) %> appearing first.
 
 ### Filters
+<% ids_filter_description = "An array of #{t(".resource_name", scope: resource)} IDs" %>
+<% custom_id_filter_description = t(".filters.ids.description", scope: resource) %>
+<% ids_description = custom_id_filter_description.include?("missing") ? ids_filter_description : custom_id_filter_description %>
 
 | Arguments          | Description
 |--------------------|--------------------
-| **ids**            | An array of <%= t(".resource_name", scope: resource) %> IDs. See [Getting Started](#filtering "Filtering") for examples.
+| **ids**            | <%= ids_description %>. See [Getting Started](#filtering "Filtering") for examples.
 | **limit**          | used for pagination (default is 50)
-| **page**           | used for pagination (default is 1)
+| **page**           | used for pagination (default is 1
+<% unless t(".filters.timestamp_search", scope: resource) == false %>
 | **created_at_min** | ISO 8601 format (e.g. 2015-11-04T00:00:00.00Z)
 | **created_at_max** | ISO 8601 format (e.g. 2015-11-04T00:00:00.00Z)
 | **updated_at_min** | ISO 8601 format (e.g. 2015-11-04T00:00:00.00Z)
 | **updated_at_max** | ISO 8601 format (e.g. 2015-11-04T00:00:00.00Z)
+<% end %>
 <% if t(".attributes", scope: resource).key?(:status) %>
   <% if !["company", "product", "purchase_order","fulfillment","order"].include?(t(".resource_name", scope: resource)) %>
     **status** | Default is `active`
@@ -46,4 +55,4 @@ Returns a list of <%= t(".resource_plural", scope: resource) %> you’ve previou
 <% end %>
 
 ### HTTP Request:
-`GET  https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>`
+`GET  https://api.tradegecko.com/<%= resource_path %>`

--- a/source/includes/_show_request.md.erb
+++ b/source/includes/_show_request.md.erb
@@ -1,18 +1,21 @@
 ## Retrieve a particular <%= t(".resource_name", scope: resource) %>
 
 <% unless t('.gecko.unavailable', scope: resource) == true %>
+<% sample_resource_id = t(".gecko.show.id", scope: resource).is_a?(Integer) ? t(".gecko.show.id", scope: resource) : 1 %>
 ```ruby
 require 'gecko-ruby'
 gecko = Gecko::Client.new(<OAUTH_ID>, <OAUTH_SECRET>)
 access_token = OAuth2::AccessToken.new(gecko.oauth_client, <ACCESS_TOKEN>)
 gecko.access_token = access_token
-gecko.<%= t(".resource_klass", scope: resource) %>.find(1)
+gecko.<%= t(".resource_klass", scope: resource) %>.find(<%= sample_resource_id %>)
 ```
 <% end %>
 
+<% plural_name = t(".resource_plural", scope: resource) %>
+<% resource_path = t(".resource_path", scope: resource).include?("missing") ? plural_name : t(".resource_path", scope: resource) %>
 ```shell
 curl -X GET -H "Content-type: application/json" -H "Authorization: Bearer <ACCESS_TOKEN>"
-https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/1
+https://api.tradegecko.com/<%= resource_path %>/<%= sample_resource_id %>
 ```
 
 ```json
@@ -24,4 +27,4 @@ https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/1
 Retrieves the details of an existing <%= t(".resource_name", scope: resource) %>. You need only supply the unique <%= t(".resource_name", scope: resource) %> identifier that was returned upon <%= t(".resource_name", scope: resource) %> creation.
 
 ### HTTP Request
-`GET https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/{RESOURCE_ID}`
+`GET https://api.tradegecko.com/<%= resource_path %>/{RESOURCE_ID}`

--- a/source/includes/_update_request.md.erb
+++ b/source/includes/_update_request.md.erb
@@ -1,6 +1,9 @@
 ## Update <%= t(".resource_article", scope: resource) %> <%= t(".resource_name", scope: resource) %>
 <% unless t('.gecko.unavailable', scope: resource) == true %>
 
+<% plural_name = t(".resource_plural", scope: resource) %>
+<% resource_path = t(".resource_path", scope: resource).include?("missing") ? plural_name : t(".resource_path", scope: resource) %>
+
 ```ruby
 require 'gecko-ruby'
 gecko = Gecko::Client.new(<OAUTH_ID>, <OAUTH_SECRET>)
@@ -16,7 +19,7 @@ gecko.access_token = access_token
 
 ```shell
 curl -X PUT -H "Content-type: application/json" -H "Authorization: Bearer <ACCESS_TOKEN>"
-https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/1 -d '{"<%= t(".resource_name", scope: resource) %>":<%= t('.gecko.update', scope: resource).to_json %>}'
+https://api.tradegecko.com/<%= resource_path %>/1 -d '{"<%= t(".resource_name", scope: resource) %>":<%= t('.gecko.update', scope: resource).to_json %>}'
 ```
 
 > Response
@@ -30,4 +33,4 @@ Any parameters not provided will be left unchanged.
 This request accepts the same arguments as the <%= t(".resource_name", scope: resource) %> creation call.
 
 ### HTTP Request
-`PUT https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/{RESOURCE_ID}`
+`PUT https://api.tradegecko.com/<%= resource_path %>/{RESOURCE_ID}`

--- a/source/includes/asides/_sideloading.md
+++ b/source/includes/asides/_sideloading.md
@@ -117,11 +117,11 @@ curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <ACCE
 ```
 
 
-### Fetching a Composition
+### Fetching a Bundle Product Variant's Composition
 
 Sideloading parameters for composition API work for both single and collection actions. Examples:
 
-`GET https://api.tradegecko.com/variants/composition?include=bundle,component`
+`GET https://api.tradegecko.com/variants/composition?include=bundle`
 
 `GET https://api.tradegecko.com/variants/composition/1?include=bundle,component`
 

--- a/source/includes/asides/_sideloading.md
+++ b/source/includes/asides/_sideloading.md
@@ -3,7 +3,7 @@
 TradeGecko allows you retrieve associated resources as part of a single request.
 This can be done by adding an `include` parameter containing a comma-separated list of resources to load.
 
-<aside class="notice">  
+<aside class="notice">
   Sideloading for Orders and Purchase Orders are currently available only when retrieving a single order or purchase order. Using the `include` parameter won't work on index pages.
 </aside>
 
@@ -113,5 +113,47 @@ curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <ACCE
       "contact_id":null,
       ...
    }
+}
+```
+
+
+### Fetching a Composition
+
+Sideloading parameters for composition API work for both single and collection actions. Examples:
+
+`GET https://api.tradegecko.com/variants/composition?include=bundle,component`
+
+`GET https://api.tradegecko.com/variants/composition/1?include=bundle,component`
+
+
+```shell
+curl -X GET -H "Content-type: application/json" -H "Authorization: Bearer <ACCESS_TOKEN>" https://api.tradegecko.com/variants/composition?include=bundle,component
+```
+
+```json--inline
+{
+   "variants": [
+      {
+         "id": 1,
+         "sku": "DRK-0001",
+         ...
+      },
+      {
+         "id": 2,
+         "sku": "DRINK-PACK-SKU",
+         ...
+      },
+      ...
+   ],
+   "composition": [
+      {
+         "bundle_sku": "DRINK-PACK-SKU",
+         "component_sku": "DRK-0001",
+         "quantity": "6.0",
+         "bundle_id": 2,
+         "component_id": 1
+      },
+      ...
+   ]
 }
 ```


### PR DESCRIPTION
### Description
Composition API exposes GET actions for single and collection bundles/packsizes under one abstraction i.e. a Composition.

#### Specs:
- [x] The ability to filter by specific bundle IDs or SKUs is given. 
        Example API: `GET variants/composition?sku[]=ABC&sku[]=CDE`
	Example API: `GET variants/composition?ids=123,124`

- [x] Sideloading capabilities are available for bundle (parent) and component (child) variants
	`variants/composition?include=bundle,component`

#### Screenshots

**Sideloading Section Augmentation**
![Composition Sideloading](https://user-images.githubusercontent.com/1311760/74303164-d0648000-4d93-11ea-9b57-2d4d650e1de0.png)

**Composition Section**
![Composition Section](https://user-images.githubusercontent.com/1311760/74303182-dce8d880-4d93-11ea-9a20-6677ccc9f06a.png)
