### PR TITLE
[ENHANCEMENT] Add component_id filter to Composition API

### DIFF
--- a/locales/composition.en.yml
+++ b/locales/composition.en.yml
@@ -59,7 +59,8 @@ en:
         name: "component_id",
         type: "Integer",
         readonly: true,
-        description: "The ID corresponding to this particular component variant of the bundle."
+        description: "The ID corresponding to this particular component variant of the bundle.",
+        filterable: "An Array of Component IDs"
       },
       component_sku: {
         name: "component_sku",

--- a/source/changes.html.md
+++ b/source/changes.html.md
@@ -22,6 +22,8 @@ for existing known issues or [create a new issue](https://github.com/tradegecko/
 ### June 2020
 Added new "FulfillmentReturn Received", and "Invoice Destroy" webhooks.
 
+Added new `component_id` array filter for Composition index endpoint.
+
 ### April 2020
 Added new "PurchaseOrder Received" webhook.
 


### PR DESCRIPTION
### Description

Composition API adds a new `component_id` array filter for GET collection.

Example API:
* `GET variants/composition?component_id[]=20`
* `GET variants/composition?component_id[]=20&component_id[]=21`
