### PR TITLE
[ENHANCEMENT] json pretty

### DIFF
--- a/source/includes/_create_request.md.erb
+++ b/source/includes/_create_request.md.erb
@@ -25,9 +25,7 @@ https://api.tradegecko.com/<%= resource.resource_path || resource.resource_plura
 ```
 
 ```json
-{
-  "<%= resource.resource_name %>": <%= json_single %>
-}
+<%= JSON.pretty_generate(Hash[resource.resource_name, json_single]) %>
 ```
 
 Creates a new <%= resource.resource_name %> object.

--- a/source/includes/_current_request.md.erb
+++ b/source/includes/_current_request.md.erb
@@ -14,9 +14,7 @@ https://api.tradegecko.com/<%= t(".resource_plural", scope: resource) %>/current
 ```
 
 ```json
-{
-  "<%= t(".resource_name", scope: resource) %>": <%= json_single %>
-}
+<%= JSON.pretty_generate(Hash[t(".resource_name", scope: resource), json_single]) %>
 ```
 
 Retrieves the details of the current <%= t(".resource_name", scope: resource) %>.

--- a/source/includes/_index_request.md.erb
+++ b/source/includes/_index_request.md.erb
@@ -20,9 +20,7 @@ https://api.tradegecko.com/<%= resource_path %>/
 ```
 
 ```json
-{
-  "<%= t(".resource_plural", scope: resource) %>": <%= json_all %>
-}
+<%= JSON.pretty_generate(Hash[t(".resource_plural", scope: resource), json_all]) %>
 ```
 
 Returns a list of <%= t(".resource_plural", scope: resource) %> you’ve previously created. The <%= t(".resource_plural", scope: resource) %> are returned in sorted order, with the most recent <%= t(".resource_plural", scope: resource) %> appearing first.

--- a/source/includes/_resource.md.erb
+++ b/source/includes/_resource.md.erb
@@ -1,7 +1,4 @@
-<% json = t(".json", scope: resource)
-  json_all = JSON.pretty_generate(json)
-  json_single = JSON.pretty_generate(json.first)
-%>
+<% json = t(".json", scope: resource) %>
 # <%= t(".resource_klass", scope: resource) %>
 <% unless t(".parent", scope: resource).to_s.include?("missing") %>
   This is an object representing <%= t(".resource_article", scope: resource) %> <%= t(".resource_name", scope: resource) %> of <%= t(".parent_article", scope: resource) %> <%= t(".parent", scope: resource) %>. <%= t(".parent_plural", scope: resource).capitalize %> can
@@ -20,19 +17,19 @@
 <% end %>
 
 <% unless t(".disable_index", scope: resource) == true %>
-  <%= partial "includes/index_request", locals: { resource: resource, json_all: json_all }  %>
+  <%= partial "includes/index_request", locals: { resource: resource, json_all: json }  %>
 <% end %>
 
 <% unless t(".disable_create", scope: resource) == true %>
-  <%= partial "includes/create_request", locals: { resource_name: resource, json_single: json_single } %>
+  <%= partial "includes/create_request", locals: { resource_name: resource, json_single: json.first  } %>
 <% end %>
 
 <% unless t(".disable_show", scope: resource) == true %>
-  <%= partial "includes/show_request", locals: { resource: resource, json_single: json_single }  %>
+  <%= partial "includes/show_request", locals: { resource: resource, json_single: json.first }  %>
 <% end %>
 
 <% if t('.current', scope: resource) == true %>
-  <%= partial "includes/current_request", locals: { resource: resource, json_single: json_single }  %>
+  <%= partial "includes/current_request", locals: { resource: resource, json_single: json.first }  %>
 <% end %>
 
 <% unless t(".disable_update", scope: resource) == true %>

--- a/source/includes/_show_request.md.erb
+++ b/source/includes/_show_request.md.erb
@@ -19,9 +19,7 @@ https://api.tradegecko.com/<%= resource_path %>/<%= sample_resource_id %>
 ```
 
 ```json
-{
-  "<%= t(".resource_name", scope: resource) %>": <%= json_single %>
-}
+<%= JSON.pretty_generate(Hash[t(".resource_name", scope: resource), json_single]) %>
 ```
 
 Retrieves the details of an existing <%= t(".resource_name", scope: resource) %>. You need only supply the unique <%= t(".resource_name", scope: resource) %> identifier that was returned upon <%= t(".resource_name", scope: resource) %> creation.


### PR DESCRIPTION
Shifting `JSON.pretty_generate` into the rendering end to ensure resource key and value are indented properly.

**BEFORE**
```json
{
  "purchase_order_line_item": {
  "id": 3,
  "created_at": "2015-11-23T11:19:50.405Z",
  "updated_at": "2015-11-23T11:19:50.405Z",
  "procurement_id": null,
  "purchase_order_id": 2,
  "tax_type_id": 3,
  "variant_id": 8,
  "base_price": null,
  "freeform": false,
  "image_url": null,
  "label": null,
  "position": 0,
  "price": "2.5",
  "quantity": "2.0",
  "tax_rate_override": null,
  "extra_cost_value": "0.0",
  "tax_rate": null
}
}
```

**AFTER**
```json
{
  "purchase_order_line_item": {
    "id": 3,
    "created_at": "2015-11-23T11:19:50.405Z",
    "updated_at": "2015-11-23T11:19:50.405Z",
    "procurement_id": null,
    "purchase_order_id": 2,
    "tax_type_id": 3,
    "variant_id": 8,
    "base_price": null,
    "freeform": false,
    "image_url": null,
    "label": null,
    "position": 0,
    "price": "2.5",
    "quantity": "2.0",
    "tax_rate_override": null,
    "extra_cost_value": "0.0",
    "tax_rate": null
  }
}
```