### PR TITLE
[ENHANCEMENT] update request attributes

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -63,4 +63,5 @@ set :port, 4567
 helpers do
   require './lib/toc_data.rb'
   require './lib/resource_wrapper.rb'
+  require './lib/ruby_hash_formatter.rb'
 end

--- a/lib/ruby_hash_formatter.rb
+++ b/lib/ruby_hash_formatter.rb
@@ -1,0 +1,5 @@
+# generate indented ruby 1.9 hash syntax
+def pretty_ruby_hash(ruby_hash)
+  hash_key_regex = /\"([a-zA-Z0-9_-]+)\":/
+  JSON.pretty_generate(ruby_hash).gsub(hash_key_regex, '\1:')
+end

--- a/source/includes/_create_request.md.erb
+++ b/source/includes/_create_request.md.erb
@@ -13,7 +13,7 @@ gecko.access_token = access_token
 <%=- resource.resource_name %>.<%= resource.child.pluralize %>.build(<%= child %>)
 <%- end %>
 <%- else -%>
-<%=- resource.resource_name %> = gecko.<%= resource.resource_klass %>.build(<%= resource.gecko[:create] %>)
+<%=- resource.resource_name %> = gecko.<%= resource.resource_klass %>.build(<%= JSON.pretty_generate(resource.gecko[:create]) %>)
 <% end %>
 <%= resource.resource_name %>.save
 ```

--- a/source/includes/_create_request.md.erb
+++ b/source/includes/_create_request.md.erb
@@ -13,7 +13,7 @@ gecko.access_token = access_token
 <%=- resource.resource_name %>.<%= resource.child.pluralize %>.build(<%= child %>)
 <%- end %>
 <%- else -%>
-<%=- resource.resource_name %> = gecko.<%= resource.resource_klass %>.build(<%= JSON.pretty_generate(resource.gecko[:create]) %>)
+<%=- resource.resource_name %> = gecko.<%= resource.resource_klass %>.build(<%= pretty_ruby_hash(resource.gecko[:create]) %>)
 <% end %>
 <%= resource.resource_name %>.save
 ```

--- a/source/includes/_update_request.md.erb
+++ b/source/includes/_update_request.md.erb
@@ -10,7 +10,7 @@ gecko = Gecko::Client.new(<OAUTH_ID>, <OAUTH_SECRET>)
 access_token = OAuth2::AccessToken.new(gecko.oauth_client, <ACCESS_TOKEN>)
 gecko.access_token = access_token
 <%= t(".resource_name", scope: resource) %> = gecko.<%= t(".resource_klass", scope: resource) %>.find(1)
-<%= t(".resource_name", scope: resource) %>.attributes = <%= JSON.pretty_generate(t(".gecko.update", scope: resource)) %>
+<%= t(".resource_name", scope: resource) %>.attributes = <%= pretty_ruby_hash(t(".gecko.update", scope: resource)) %>
 <%= t(".resource_name", scope: resource) %>.save
 ```
 <% end %>

--- a/source/includes/_update_request.md.erb
+++ b/source/includes/_update_request.md.erb
@@ -10,9 +10,7 @@ gecko = Gecko::Client.new(<OAUTH_ID>, <OAUTH_SECRET>)
 access_token = OAuth2::AccessToken.new(gecko.oauth_client, <ACCESS_TOKEN>)
 gecko.access_token = access_token
 <%= t(".resource_name", scope: resource) %> = gecko.<%= t(".resource_klass", scope: resource) %>.find(1)
-<%= t(".resource_name", scope: resource) %>.attributes = {
-  rate: "12.0",
-}
+<%= t(".resource_name", scope: resource) %>.attributes = <%= t(".gecko.update", scope: resource) %>
 <%= t(".resource_name", scope: resource) %>.save
 ```
 <% end %>

--- a/source/includes/_update_request.md.erb
+++ b/source/includes/_update_request.md.erb
@@ -10,7 +10,7 @@ gecko = Gecko::Client.new(<OAUTH_ID>, <OAUTH_SECRET>)
 access_token = OAuth2::AccessToken.new(gecko.oauth_client, <ACCESS_TOKEN>)
 gecko.access_token = access_token
 <%= t(".resource_name", scope: resource) %> = gecko.<%= t(".resource_klass", scope: resource) %>.find(1)
-<%= t(".resource_name", scope: resource) %>.attributes = <%= t(".gecko.update", scope: resource) %>
+<%= t(".resource_name", scope: resource) %>.attributes = <%= JSON.pretty_generate(t(".gecko.update", scope: resource)) %>
 <%= t(".resource_name", scope: resource) %>.save
 ```
 <% end %>


### PR DESCRIPTION
This probably being missed since the start. `update` attributes under `ruby/shell` are currently hardcoded for every resource

**BEFORE**
![image](https://user-images.githubusercontent.com/6453214/86880621-8784dd80-c11f-11ea-9379-a5c4fd28b3ba.png)
![image](https://user-images.githubusercontent.com/6453214/86880634-8ce22800-c11f-11ea-86d6-59235decf50d.png)


**AFTER**
![image](https://user-images.githubusercontent.com/6453214/86880545-6de39600-c11f-11ea-8fb0-37ebcbc33043.png)
![image](https://user-images.githubusercontent.com/6453214/86880565-74720d80-c11f-11ea-86e5-1f22913f6d96.png)


