### PR TITLE
[LIBRARY] Remove access token from the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.npmrc
 coverage
 InstalledFiles
 lib/bundler/man

--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,0 +1,3 @@
+registry=https://npm.pkg.github.com/tradegecko
+_authToken=TOKEN
+//npm.pkg.github.com:_authToken=TOKEN

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Look in changes.html
 
 Look in the appropriate .yml file.
 
+# Setup
+
+Create a `.npmrc` file in the project directory based on `.npmrc.template`
+and replace `TOKEN` with the personal access token.
+
 # Deploy
 
 ./deploy.sh

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tradegecko/styles@git+https://50f35d54e06c3a4dc3408924d232d16f522ab729:x-oauth-basic@github.com/tradegecko/tradegecko-assets.git":
+"@tradegecko/styles@git+https://github.com/tradegecko/tradegecko-assets.git":
   version "0.0.1"
-  resolved "git+https://50f35d54e06c3a4dc3408924d232d16f522ab729:x-oauth-basic@github.com/tradegecko/tradegecko-assets.git#6ffb16df155d2d2b1376b16238471fae38ea9041"
+  resolved "git+https://github.com/tradegecko/tradegecko-assets.git#6ffb16df155d2d2b1376b16238471fae38ea9041"
 
 bootstrap@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
### Description

We can remove the token from `yarn.lock` by creating a `.npmrc` file in the project directory that we don't commit.
