### PR TITLE
[REVERT] Remove .npmrc setup (not needed anymore)

### DIFF
--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,3 +1,0 @@
-registry=https://npm.pkg.github.com/tradegecko
-_authToken=TOKEN
-//npm.pkg.github.com:_authToken=TOKEN

--- a/README.md
+++ b/README.md
@@ -53,16 +53,13 @@ Look in the appropriate .yml file.
 
 # Setup
 
-1. Create a `.npmrc` file in the project directory based on `.npmrc.template`
-and replace `TOKEN` with the personal access token.
-
-2. Install dependencies
+1. Install dependencies
 ```bash
 bundle install
 yarn install
 ```
 
-3. Run the server
+2. Run the server
 ```bash
 bundle exec middleman server
 ```


### PR DESCRIPTION
tradegecko-assets is now public so we don't need the extra authentication token setup.
