### PR TITLE
Enable StockTransfer destroy API page

### DIFF
--- a/locales/stock_transfer.en.yml
+++ b/locales/stock_transfer.en.yml
@@ -4,7 +4,6 @@ en:
     enable_actions: true
     child: "stock_transfer_line_item"
     disable_update: true
-    disable_destroy: true
     resource_article: "a"
     resource_klass: "StockTransfer"
     resource_name: "stock_transfer"


### PR DESCRIPTION
StockTransfer destroy API is now available in TradeGecko. This will enable this endpoint in the doc.