### PR TITLE
[TWEAK] Update address update response

### DIFF
--- a/locales/address.en.yml
+++ b/locales/address.en.yml
@@ -10,6 +10,7 @@ en:
     resource_name: "address"
     resource_plural: "addresses"
     used_in_sales_order: true
+    update_returns_200: true
     json: [
       {
         id: 6,

--- a/source/includes/_update_request.md.erb
+++ b/source/includes/_update_request.md.erb
@@ -20,9 +20,15 @@ curl -X PUT -H "Content-type: application/json" -H "Authorization: Bearer <ACCES
 https://api.tradegecko.com/<%= resource_path %>/1 -d '{"<%= t(".resource_name", scope: resource) %>":<%= t('.gecko.update', scope: resource).to_json %>}'
 ```
 
+<% if t(".update_returns_200", scope: resource) == true %>
+> Response
+>
+> Returns 200 status when the <%= t(".resource_name", scope: resource) %> gets updated successfully.
+<% else %>
 > Response
 >
 > Returns 204 status when the <%= t(".resource_name", scope: resource) %> gets updated successfully.
+<% end %>
 
 
 Updates the specified <%= t(".resource_name", scope: resource) %> by setting the values of the parameters passed.


### PR DESCRIPTION
Update address update response to reflect that we now return a HTTP status code of 200 instead of 204. This change was made via https://github.com/tradegecko/tradegecko/commit/8801559d4e267454672f5d8ae6beaaeac3d6ae16

![image](https://user-images.githubusercontent.com/9844923/89274255-3e1ea400-d673-11ea-9076-f7019823bfc8.png)

